### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,7 @@ Software
 -  Arduino-1.8.3
 -  ESP8266/Arduino :Additional Boards Manager URL:
    http://arduino.esp8266.com/stable/package\_esp8266com\_index.json
+-  Arduino ESP8266 filesystem uploader https://github.com/esp8266/arduino-esp8266fs-plugin
 -  Time 1.5.0 https://github.com/PaulStoffregen/Time
 -  SimpleTimer https://github.com/jfturcot/SimpleTimer
    (http://playground.arduino.cc/Code/SimpleTimer)
@@ -144,6 +145,8 @@ changes to the contents of data-uncompressed, you don't need to do this step.
 
 Upload the contents of the data folder with MkSPIFFS Tool
 ("ESP8266 Sketch Data Upload" in Tools menu in Arduino IDE)
+
+Uncomment the line //#define INCLUDE_DS1307 as we are not using that type of rtc and don't have the library
 
 Then compile and upload the .ino.
 


### PR DESCRIPTION
Added the Esp file transfer tool to the list as you need it like a library installed before

and added a hint to uncomment line 40 to exclude ds1307 rtc of which we miss the library to support it